### PR TITLE
correct update product without slug

### DIFF
--- a/src/products/admin/admin-products.service.ts
+++ b/src/products/admin/admin-products.service.ts
@@ -44,11 +44,15 @@ export class AdminProductsService {
   }
 
   async update(id: string, updateProductDto: UpdateProductDto) {
-    let product = await this.prismaService.product.findFirst({
-      where: {
-        slug: updateProductDto.slug,
-      },
-    });
+    let product = null;
+
+    if (updateProductDto.slug) {
+      product = await this.prismaService.product.findFirst({
+        where: {
+          slug: updateProductDto.slug,
+        },
+      });
+    }
 
     if (product && product.id !== id) {
       throw new ProductSlugAlreadyExistsError(updateProductDto.slug);


### PR DESCRIPTION
Na função **update** do arquivo localizado em: **src/products/admin/admin-products.service.ts**:

![image](https://github.com/user-attachments/assets/410ce493-82d8-4b16-9cea-1e6ff5bc6f83)

A consulta está sendo feita com findFirst de forma incorreta, pois não é obrigatório enviar o slug do produto, e caso ele não seja passado, por se tratar de find**First**, ele irá ficar sem filtro de busca e retornar o primeiro produto, dando erro que o slug já está cadastrado, mesmo não sendo ele que queremos modificar:

![image](https://github.com/user-attachments/assets/0cd0eba9-6b59-4f62-a979-e0544713b572)

Nesse caso, a solução é simples, apenas executamos a consulta com base no slug caso o mesmo seja passado, pois caso não seja passado, ai sim retornará null.

Print da mesma consulta com o código corrigido:

![image](https://github.com/user-attachments/assets/047f8d39-388b-498d-b0a3-e4204df9be61)

Obs: É meu primeiro PR, então relevem qualquer falha, obrigado!